### PR TITLE
fix: handling of the backslash character

### DIFF
--- a/lib/html2js.js
+++ b/lib/html2js.js
@@ -6,7 +6,7 @@ var TEMPLATE = 'angular.module(\'%s\', []).run(function($templateCache) {\n' +
     '});\n';
 
 var escapeContent = function(content) {
-  return content.replace(/'/g, '\\\'').replace(/\r?\n/g, '\\n\' +\n    \'');
+  return content.replace(/\\/g, '\\\\').replace(/'/g, '\\\'').replace(/\r?\n/g, '\\n\' +\n    \'');
 };
 
 var createHtml2JsPreprocessor = function(logger, basePath, config) {

--- a/test/html2js.spec.coffee
+++ b/test/html2js.spec.coffee
@@ -54,3 +54,10 @@ describe 'preprocessors html2js', ->
     process 'first\r\nsecond', file, (processedContent) ->
       expect(processedContent).to.not.contain '\r'
       done()
+
+  it 'should preserve the backslash character', (done) ->
+    file = new File '/base/path/file.html'
+
+    process 'first\\second', file, (processedContent) ->
+      expect(removeSpacesFrom processedContent).to.contain "'first\\\\second'"
+      done()


### PR DESCRIPTION
Escape the backslash character when this is present in a template
