### PR TITLE
Add missing plugins section to the sample config file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ module.exports = function(config) {
       '**/*.html': ['ng-html2js']
     },
 
+    plugins: [
+      "karma-coffee-preprocessor"
+    },
+
     files: [
       '*.js',
       '*.html'


### PR DESCRIPTION
`plugins` section was missing in the sample config file and I had to spend some time on trying figure out how to fix this kind of problem:

```
karma start test/karma-fast.conf.coffee --single-run                  
WARN [preprocess]: Can not load "html2js", it is not registered!
  Perhaps you are missing some plugin?
PhantomJS 1.8.2 (Linux) ERROR
        SyntaxError: Parse error
        at /home/lucassus/Projects/OpenSource/angular-seed/app/templates/alerts.html:1
```
