### PR TITLE
Make template file location declaration explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,10 @@ module.exports = function(config) {
 
     files: [
       '*.js',
-      '*.html'
+      '*.html',
+      // if template files are in nested directories, you must specify this
+      // or html2js will not see them and tests will produce 'No module:' errors
+      '**/*.html'
     ],
 
     ngHtml2JsPreprocessor: {


### PR DESCRIPTION
It may seem moronic, but I lost hours to this, because ng-html2js does not find nested .html files with the example configuration here (*.html). This is what was causing Issue 15.
