### PR TITLE
Specify 'engines' field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,9 @@
   "peerDependencies": {
     "karma": ">=0.9"
   },
+  "engines": {
+    "node": "~0.10"
+  },
   "license": "MIT",
   "contributors": [
     "Friedel Ziegelmayer <friedel.ziegelmayer@gmail.com>",


### PR DESCRIPTION
We started testing on circleci.com and all our directive tests failed with a message like the one you see below while all tests passed on our dev machines.

```
Directive: areas
    ✗ should be replaced by video-list-areas ul   Error: [$injector:modulerr] Failed to instantiate module html2js due to:
    Error: [$injector:nomod] Module 'html2js' is not available! You either misspelled the module name or forgot to load it. If registering a module ensure that you specify the dependencies as the second argument.
    http://errors.angularjs.org/1.2.11/$injector/nomod?p0=html2js
        at /home/frederik/development/video-list/bower_components/angular/angular.js:1531
        at ensure (/home/frederik/development/video-list/bower_components/angular/angular.js:1454)
        at module (/home/frederik/development/video-list/bower_components/angular/angular.js:1741)
        at /home/frederik/development/video-list/bower_components/angular/angular.js:3619
    http://errors.angularjs.org/1.2.11/$injector/modulerr?p0=html2js&p1=Error%3A%20%5B%24injector%3Anomod%5D%20Module%20'html2js'%20is%20not%20available!%20You%20either%20misspelled%20the%20module%20name%20or%20forgot%20to%20load%20it.%20If%20registering%20a%20module%20ensure%20that%20you%20specify%20the%20dependencies%20as%20the%20second%20argument.%0Ahttp%3A%2F%2Ferrors.angularjs.org%2F1.2.11%2F%24injector%2Fnomod%3Fp0%3Dhtml2js%0A%20%20%20%20at%20http%3A%2F%2Flocalhost%3A9878%2Fbase%2Fbower_components%2Fangular%2Fangular.js%3F1391449381000%3A1531%0A%20%20%20%20at%20ensure%20(http%3A%2F%2Flocalhost%3A9878%2Fbase%2Fbower_components%2Fangular%2Fangular.js%3F1391449381000%3A1454)%0A%20%20%20%20at%20module%20(http%3A%2F%2Flocalhost%3A9878%2Fbase%2Fbower_components%2Fangular%2Fangular.js%3F1391449381000%3A1741)%0A%20%20%20%20at%20http%3A%2F%2Flocalhost%3A9878%2Fbase%2Fbower_components%2Fangular%2Fangular.js%3F1391449381000%3A3619
        at /home/frederik/development/video-list/bower_components/angular/angular.js:3648
    Error: [$injector:modulerr] Failed to instantiate module html2js due to:
    Error: [$injector:nomod] Module 'html2js' is not available! You either misspelled the module name or forgot to load it. If registering a module ensure that you specify the dependencies as the second argument.
    http://errors.angularjs.org/1.2.11/$injector/nomod?p0=html2js
        at /home/frederik/development/video-list/bower_components/angular/angular.js:1531
        at ensure (/home/frederik/development/video-list/bower_components/angular/angular.js:1454)
        at module (/home/frederik/development/video-list/bower_components/angular/angular.js:1741)
        at /home/frederik/development/video-list/bower_components/angular/angular.js:3619
    http://errors.angularjs.org/1.2.11/$injector/modulerr?p0=html2js&p1=Error%3A%20%5B%24injector%3Anomod%5D%20Module%20'html2js'%20is%20not%20available!%20You%20either%20misspelled%20the%20module%20name%20or%20forgot%20to%20load%20it.%20If%20registering%20a%20module%20ensure%20that%20you%20specify%20the%20dependencies%20as%20the%20second%20argument.%0Ahttp%3A%2F%2Ferrors.angularjs.org%2F1.2.11%2F%24injector%2Fnomod%3Fp0%3Dhtml2js%0A%20%20%20%20at%20http%3A%2F%2Flocalhost%3A9878%2Fbase%2Fbower_components%2Fangular%2Fangular.js%3F1391449381000%3A1531%0A%20%20%20%20at%20ensure%20(http%3A%2F%2Flocalhost%3A9878%2Fbase%2Fbower_components%2Fangular%2Fangular.js%3F1391449381000%3A1454)%0A%20%20%20%20at%20module%20(http%3A%2F%2Flocalhost%3A9878%2Fbase%2Fbower_components%2Fangular%2Fangular.js%3F1391449381000%3A1741)%0A%20%20%20%20at%20http%3A%2F%2Flocalhost%3A9878%2Fbase%2Fbower_components%2Fangular%2Fangular.js%3F1391449381000%3A3619
        at /home/frederik/development/video-list/bower_components/angular/angular.js:3648
    TypeError: 'null' is not an object (evaluating 'this.actual.hasClass')
        at /home/frederik/development/video-list/test/lib/matchers.js:7
        at /home/frederik/development/video-list/test/unit/directives/areas.js:25
```

Part of our karma.conf.coffee:

```
    preprocessor:
      '**/*.coffee': ['coffee']
      '**/*.html': ['ng-html2js']

    ngHtml2JsPreprocessor:
      moduleName: 'html2js'
```

As standard circleci uses node version v0.8.12 while we have v0.10.26 on our machines. After a while of debugging we figured out that a version >= v0.9.3 is needed.

I suggest to add an `engines` field to package.json for node ~0.10. A version >= 0.9.3 is needed, but all 0.9.x versions are unstable. Furthermore karma has specified `"node": "~0.8 || ~0.10"` so a 0.9.x version won't work with karma.
