### PR TITLE
Relax karma peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "grunt-auto-release": "~0.0.2"
   },
   "peerDependencies": {
-    "karma": ">=0.9"
+    "karma": "~0.10"
   },
   "license": "MIT",
   "contributors": [


### PR DESCRIPTION
Hi,

We are currently using karma-ng-html2js-preprocessor (0.1.0) with grunt-karma (0.6/0.8) and they complain about its peerDependencies

We tried to degrade/upgrade conflicting versions but the only solution was to update the preprocessor peer dependency version,

Could it be added to a new release?
