### PR TITLE
Dont append .js to path more than once

### DIFF
--- a/lib/html2js.js
+++ b/lib/html2js.js
@@ -36,7 +36,9 @@ var createHtml2JsPreprocessor = function(logger, basePath, config) {
 
     var htmlPath = cacheIdFromPath(file.originalPath.replace(basePath + '/', ''));
 
-    file.path = file.path + '.js';
+    if (!/\.js$/.test(file.path)) {
+      file.path = file.path + '.js';
+    }
 
     if (moduleName) {
       done(util.format(SINGLE_MODULE_TPL, moduleName, moduleName, htmlPath, escapeContent(content)));

--- a/test/html2js.spec.coffee
+++ b/test/html2js.spec.coffee
@@ -43,6 +43,13 @@ describe 'preprocessors html2js', ->
       expect(file.path).to.equal '/base/path/file.html.js'
       done()
 
+  it 'should not append *.js to a processed file\'s path more than once', (done) ->
+    file = new File '/base/path/file.html'
+
+    process '', file, (processedContent) ->
+      process '', file, (processedContent) ->
+        expect(file.path).to.equal '/base/path/file.html.js'
+        done()
 
   it 'should preserve new lines', (done) ->
     file = new File '/base/path/file.html'


### PR DESCRIPTION
I am working on a slimrb preprocessor and the repeated appending of .js to a file's path in interactivemode was causing some issues.
