### PR TITLE
html2js: add templatePathReplaces attribute for renaming template paths

### DIFF
--- a/lib/html2js.js
+++ b/lib/html2js.js
@@ -27,8 +27,14 @@ var createHtml2JsPreprocessor = function(logger, basePath, config) {
   var moduleName = config.moduleName;
   var stripPrefix = new RegExp('^' + (config.stripPrefix || ''));
   var prependPrefix = config.prependPrefix || '';
+  var templatePathReplaces = config.templatePathReplaces || [];
+
   var cacheIdFromPath = config && config.cacheIdFromPath || function(filepath) {
-    return prependPrefix + filepath.replace(stripPrefix, '');
+    var preparedPath = prependPrefix + filepath.replace(stripPrefix, '');
+    templatePathReplaces.forEach(function (path) {
+      preparedPath = preparedPath.replace(path.pattern, path.replacement);
+    });
+    return preparedPath;
   };
 
   return function(content, file, done) {

--- a/test/html2js.spec.coffee
+++ b/test/html2js.spec.coffee
@@ -126,6 +126,73 @@ describe 'preprocessors html2js', ->
             .to.haveContent HTML
           done()
 
+    describe 'templatePathReplaces', ->
+      describe 'transforms path via all the matching regexps', ->
+
+        it 'ignores unmatching regexps', (done) ->
+
+          process = createPreprocessor
+            templatePathReplaces: [
+              {
+                pattern: /doesntmatch/
+                replacement: 'bar'
+              },
+            ]
+
+          file = new File '/base/path/file.html'
+          HTML = '<html></html>'
+
+          process HTML, file, (processedContent) ->
+            expect(processedContent)
+              .to.defineModule('path/file.html').and
+              .to.defineTemplateId('path/file.html').and
+              .to.haveContent HTML
+            done()
+
+        it 'transforms path via the regexp', (done) ->
+
+          process = createPreprocessor
+            templatePathReplaces: [
+              {
+                pattern: /path/
+                replacement: 'bar'
+              },
+            ]
+
+          file = new File '/base/path/file.html'
+          HTML = '<html></html>'
+
+          process HTML, file, (processedContent) ->
+            expect(processedContent)
+              .to.defineModule('bar/file.html').and
+              .to.defineTemplateId('bar/file.html').and
+              .to.haveContent HTML
+            done()
+
+        it 'transforms path with subsequent matching regexps', (done) ->
+
+          process = createPreprocessor
+            templatePathReplaces: [
+              {
+                pattern: /path/
+                replacement: 'bar'
+              },
+              {
+                pattern: /bar/
+                replacement: 'foo'
+              },
+            ]
+
+          file = new File '/base/path/file.html'
+          HTML = '<html></html>'
+
+          process HTML, file, (processedContent) ->
+            expect(processedContent)
+              .to.defineModule('foo/file.html').and
+              .to.defineTemplateId('foo/file.html').and
+              .to.haveContent HTML
+            done()
+
     describe 'moduleName', ->
       beforeEach ->
         process = createPreprocessor


### PR DESCRIPTION
This patch implements another config option to the html2js preprocessor,
namely it allows the user to transform paths via a list of regexps,
instead of passing the cacheIdFromPath callback.

The reason passing that callback is complicated is that it already
has some functionality (prependPrefix and stripPrefix), which would have
to be reimplemented in the user supplied callback, which is further
complicated by the fact that those are stored in the closure hidden from
the callback function.

Signed-off-by: Adam Golya golya@balabit.com
Signed-off-by: Balazs Scheidler bazsi@balabit.com
