### PR TITLE
Added dynamic replacement of string in prefix/suffix parsing

### DIFF
--- a/lib/html2js.js
+++ b/lib/html2js.js
@@ -29,6 +29,19 @@ var createHtml2JsPreprocessor = function(logger, basePath, config) {
   var prependPrefix = config.prependPrefix || '';
   var stripSufix = new RegExp((config.stripSufix || '') + '$');
   var cacheIdFromPath = config && config.cacheIdFromPath || function(filepath) {
+    var pathReplacement;
+    var thisPrependPrefix = '';
+    // Find any replacements
+    if (pathReplacement = stripPrefix.exec(filepath)) {
+        // Replace each
+        for (var i = 1; i < pathReplacement.length; i++) {
+            thisPrependPrefix = prependPrefix.replace('{$' + i + '}', pathReplacement[i]);
+        }
+    }
+    // If replacements done, use that
+    if (typeof thisPrependPrefix !== 'undefined') {
+        return thisPrependPrefix + filepath.replace(stripPrefix, '').replace(stripSufix, '');
+    }
     return prependPrefix + filepath.replace(stripPrefix, '').replace(stripSufix, '');
   };
 


### PR DESCRIPTION
I found that I was unable to successfully create the template cache values for directives existing in different directories which are unparseable by the standard stripPrefix and prependPrefix options. For example, I had directives in:

'packages/custom/recentprojects/public/views/directiveTemplates/recent-projects.html'
and
'packages/users/public/views/directiveTemplates/team-members.html'

These needed to be turned into:

'recentprojects/views/directiveTemplates/recent-projects.html'
and
'users/views/directiveTemplates/recent-projects.html'

So, I had to strip out everything before public, and then insert prefixes which are different. Since reinsertion of the package name was required, I wrote up a quick regex fix that would allow that to happen. It works as follows:

stripPrefix: '._/(._)/public/views/directiveTemplates/',
prependPrefix: '{$1}/views/directiveTemplates/',

With {$1} being the first capturing subgroup, {$2} being the second, etc.

Hopefully this can help someone.
