### PR TITLE
Removing the html2js name overwrite

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,4 @@
 // PUBLISH DI MODULE
 module.exports = {
   'preprocessor:ng-html2js': ['factory', require('./html2js')],
-  // TODO(vojta): remove this in 0.11
-  'preprocessor:html2js': ['factory', require('./html2js')]
 };


### PR DESCRIPTION
This causes issues when you need to use both pre processors