### PR TITLE
Show karma `plugins` config in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ npm install karma-ng-html2js-preprocessor --save-dev
 // karma.conf.js
 module.exports = function(config) {
   config.set({
+    plugins : [
+      'karma-ng-html2js-preprocessor',
+    ],
+
     preprocessors: {
       '**/*.html': ['ng-html2js']
     },


### PR DESCRIPTION
This line is necessary to have karma load the plugin. I forgot it and spent a little while being very confused. Would be helpful if the docs show this to save me from myself.