### PR TITLE
Add requirejs support to karma-ng-html2js-preprocessor.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,14 @@ module.exports = function(config) {
 
       // setting this option will create only a single module that contains templates
       // from all the files, so you can load them all with module('foo')
-      moduleName: 'foo'
+      moduleName: 'foo',
+      // setting this option will use require.js to wrap the preprocessed templates
+      // if karma.frameworks contains 'requirejs' you only need to specify this
+      // option set if you are using non-default values
+      require: {
+        // the name of the angular shim, defaults to angular
+        angularShim: 'angular'
+      }
     }
   });
 };
@@ -74,6 +81,27 @@ angular.module('template.html', []).config(function($templateCache) {
 ```
 
 See the [ng-directive-testing](https://github.com/vojtajina/ng-directive-testing) for a complete example.
+
+----
+
+The dependencies for the test-main.js file should be modified according to the code example below to properly load the templates as requirements for the test.
+
+```js
+var dependencies = [];
+
+var DEP_REGEXP = /(Spec|\.html)\.js$/;
+
+var pathToModule = function(path) {
+    return path.replace(/^\/base\//, '').replace(/\.js$/, '');
+};
+
+Object.keys(window.__karma__.files).forEach(function(file) {
+    if (DEP_REGEXP.test(file)) {
+        // Normalize paths to RequireJS module names.
+        dependencies.push(pathToModule(file));
+    }
+});
+```
 
 ----
 

--- a/lib/html2js.js
+++ b/lib/html2js.js
@@ -5,6 +5,13 @@ var TEMPLATE = 'angular.module(\'%s\', []).run(function($templateCache) {\n' +
     '  $templateCache.put(\'%s\',\n    \'%s\');\n' +
     '});\n';
 
+var TEMPLATE_REQUIRE =
+    'require([\'%s\'], function(angular) {\n' +
+    '  angular.module(\'%s\', []).run(function($templateCache) {\n' +
+    '    $templateCache.put(\'%s\',\n    \'%s\');\n' +
+    '  });\n' +
+    '});\n';
+
 var SINGLE_MODULE_TPL = '(function(module) {\n' +
     'try {\n' +
     '  module = angular.module(\'%s\');\n' +
@@ -16,11 +23,25 @@ var SINGLE_MODULE_TPL = '(function(module) {\n' +
     '});\n' +
     '})();\n';
 
+var SINGLE_MODULE_REQUIRE_TPL =
+    'require([\'%s\'], function(angular) {\n' +
+    '  var module;\n' +
+    '  try {\n' +
+    '    module = angular.module(\'%s\');\n' +
+    '  } catch (e) {\n' +
+    '    module = angular.module(\'%s\', []);\n' +
+    '  }\n' +
+    '  module.run(function($templateCache) {\n' +
+    '    $templateCache.put(\'%s\',\n    \'%s\');\n' +
+    '  });\n' +
+    '});\n';
+
+
 var escapeContent = function(content) {
   return content.replace(/\\/g, '\\\\').replace(/'/g, '\\\'').replace(/\r?\n/g, '\\n\' +\n    \'');
 };
 
-var createHtml2JsPreprocessor = function(logger, basePath, config) {
+var createHtml2JsPreprocessor = function(logger, basePath, config, frameworks) {
   config = typeof config === 'object' ? config : {};
 
   var log = logger.create('preprocessor.html2js');
@@ -32,23 +53,39 @@ var createHtml2JsPreprocessor = function(logger, basePath, config) {
     return prependPrefix + filepath.replace(stripPrefix, '').replace(stripSufix, '');
   };
 
+  // require.js additions
+  var useRequire = frameworks && frameworks.indexOf('requirejs') !== -1 || Boolean(config.require);
+  var angularShim = config.require && config.require.angularShim || 'angular';
+
   return function(content, file, done) {
     log.debug('Processing "%s".', file.originalPath);
 
     var htmlPath = cacheIdFromPath(file.originalPath.replace(basePath + '/', ''));
+
+    if (useRequire) {
+      file.path = basePath + '/' + htmlPath.replace(/\//g, '-');
+    }
 
     if (!/\.js$/.test(file.path)) {
       file.path = file.path + '.js';
     }
 
     if (moduleName) {
-      done(util.format(SINGLE_MODULE_TPL, moduleName, moduleName, htmlPath, escapeContent(content)));
+      if (useRequire) {
+        done(util.format(SINGLE_MODULE_REQUIRE_TPL, angularShim, moduleName, moduleName, htmlPath, escapeContent(content)));
+      } else {
+        done(util.format(SINGLE_MODULE_TPL, moduleName, moduleName, htmlPath, escapeContent(content)));
+      }
     } else {
-      done(util.format(TEMPLATE, htmlPath, htmlPath, escapeContent(content)));
+      if (useRequire) {
+        done(util.format(TEMPLATE_REQUIRE, angularShim, htmlPath, htmlPath, escapeContent(content)));
+      } else {
+        done(util.format(TEMPLATE, htmlPath, htmlPath, escapeContent(content)));
+      }
     }
   };
 };
 
-createHtml2JsPreprocessor.$inject = ['logger', 'config.basePath', 'config.ngHtml2JsPreprocessor'];
+createHtml2JsPreprocessor.$inject = ['logger', 'config.basePath', 'config.ngHtml2JsPreprocessor', 'config.frameworks'];
 
 module.exports = createHtml2JsPreprocessor;


### PR DESCRIPTION
Users can enable requirejs by using the requirejs framework or adding the config
property of require to the karma config file.  The require config property may
contain a name to use when referring to the angular shim, by default it is
'angular'.

The README has been updated with this information and includes steps to take
to modify the test-main.js file.  The instructions supersede the the karma+
requirejs instructions for those using angular.