### PR TITLE
fix: Suffix is misspelled

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ module.exports = function(config) {
     ngHtml2JsPreprocessor: {
       // strip this from the file path
       stripPrefix: 'public/',
-      stripSufix: '.ext',
+      stripSuffix: '.ext',
       // prepend this to the
       prependPrefix: 'served/',
 

--- a/lib/html2js.js
+++ b/lib/html2js.js
@@ -27,7 +27,7 @@ var createHtml2JsPreprocessor = function(logger, basePath, config) {
   var moduleName = config.moduleName;
   var stripPrefix = new RegExp('^' + (config.stripPrefix || ''));
   var prependPrefix = config.prependPrefix || '';
-  var stripSufix = new RegExp((config.stripSufix || '') + '$');
+  var stripSufix = new RegExp((config.stripSuffix || config.stripSufix || '') + '$');
   var cacheIdFromPath = config && config.cacheIdFromPath || function(filepath) {
     return prependPrefix + filepath.replace(stripPrefix, '').replace(stripSufix, '');
   };

--- a/test/html2js.spec.coffee
+++ b/test/html2js.spec.coffee
@@ -116,6 +116,22 @@ describe 'preprocessors html2js', ->
           done()
 
 
+    describe 'stripSuffix', ->
+      beforeEach ->
+        process = createPreprocessor stripSuffix: '.ext'
+
+      it 'strips the given suffix from the file path', (done) ->
+        file = new File 'file.html.ext'
+        HTML = '<html></html>'
+
+        process HTML, file, (processedContent) ->
+          expect(processedContent)
+            .to.defineModule('file.html').and
+            .to.defineTemplateId('file.html').and
+            .to.haveContent HTML
+          done()
+
+
     describe 'stripSufix', ->
       beforeEach ->
         process = createPreprocessor stripSufix: '.ext'


### PR DESCRIPTION
Both versions (stripSufix and stripSuffix) are supported for backward-compatibility

Closes #56