### PR TITLE
feat: Multiple module names

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,13 +50,60 @@ module.exports = function(config) {
         return cacheId;
       },
 
-      // setting this option will create only a single module that contains templates
-      // from all the files, so you can load them all with module('foo')
+      // - setting this option will create only a single module that contains templates
+      //   from all the files, so you can load them all with module('foo')
+      // - you may provide a function(htmlPath, originalPath) instead of a string
+      //   if you'd like to generate modules dynamically
+      //   htmlPath is a originalPath stripped and/or prepended
+      //   with all provided suffixes and prefixes
       moduleName: 'foo'
     }
   });
 };
 ```
+
+### Multiple module names
+
+Use *function* if more than one module that contains templates is required.
+
+```js
+// karma.conf.js
+module.exports = function(config) {
+  config.set({
+    // ...
+
+    ngHtml2JsPreprocessor: {
+      // ...
+
+      moduleName: function (htmlPath, originalPath) {
+        return htmlPath.split('/')[0];
+      }
+    }
+  });
+};
+```
+
+If only some of the templates should be placed in the modules,
+return `''`, `null` or `undefined` for those which should not.
+
+```js
+// karma.conf.js
+module.exports = function(config) {
+  config.set({
+    // ...
+
+    ngHtml2JsPreprocessor: {
+      // ...
+
+      moduleName: function (htmlPath, originalPath) {
+        var module = htmlPath.split('/')[0];
+        return module !== 'tpl' ? module : null;
+      }
+    }
+  });
+};
+```
+
 
 ## How does it work ?
 

--- a/lib/html2js.js
+++ b/lib/html2js.js
@@ -24,7 +24,9 @@ var createHtml2JsPreprocessor = function(logger, basePath, config) {
   config = typeof config === 'object' ? config : {};
 
   var log = logger.create('preprocessor.html2js');
-  var moduleName = config.moduleName;
+  var getModuleName = typeof config.moduleName === 'function' ? config.moduleName : function () {
+    return config.moduleName;
+  };
   var stripPrefix = new RegExp('^' + (config.stripPrefix || ''));
   var prependPrefix = config.prependPrefix || '';
   var stripSufix = new RegExp((config.stripSufix || '') + '$');
@@ -35,7 +37,9 @@ var createHtml2JsPreprocessor = function(logger, basePath, config) {
   return function(content, file, done) {
     log.debug('Processing "%s".', file.originalPath);
 
-    var htmlPath = cacheIdFromPath(file.originalPath.replace(basePath + '/', ''));
+    var originalPath = file.originalPath.replace(basePath + '/', '');
+    var htmlPath = cacheIdFromPath(originalPath);
+    var moduleName = getModuleName(htmlPath, originalPath);
 
     if (!/\.js$/.test(file.path)) {
       file.path = file.path + '.js';

--- a/test/html2js.spec.coffee
+++ b/test/html2js.spec.coffee
@@ -151,11 +151,9 @@ describe 'preprocessors html2js', ->
           done()
 
     describe 'moduleName', ->
-      beforeEach ->
+      it 'should generate code with a given module name', ->
         process = createPreprocessor
           moduleName: 'foo'
-
-      it 'should generate code with a given module name', ->
         file1 = new File '/base/tpl/one.html'
         HTML1 = '<span>one</span>'
         file2 = new File '/base/tpl/two.html'
@@ -175,3 +173,40 @@ describe 'preprocessors html2js', ->
           .to.haveContent(HTML1).and
           .to.defineTemplateId('tpl/two.html').and
           .to.haveContent(HTML2)
+
+
+      it 'should generate code with multiple module names', ->
+        process = createPreprocessor
+          moduleName: (htmlPath) ->
+            module = htmlPath.split('/')[0]
+            if module != 'tpl'
+              module
+
+        file1 = new File '/base/app/one.html'
+        HTML1 = '<span>one</span>'
+        file2 = new File '/base/common/two.html'
+        HTML2 = '<span>two</span>'
+        file3 = new File '/base/tpl/three.html'
+        HTML3 = '<span>three</span>'
+        threeFilesContent = ''
+
+        process HTML1, file1, (processedContent) ->
+          threeFilesContent += processedContent
+
+        process HTML2, file2, (processedContent) ->
+          threeFilesContent += processedContent
+
+        process HTML3, file3, (processedContent) ->
+          threeFilesContent += processedContent
+
+        # evaluate three files (to simulate multiple module names)
+        expect(threeFilesContent)
+          .to.defineModule('app').and
+          .to.defineTemplateId('app/one.html').and
+          .to.haveContent(HTML1).and
+          .to.defineModule('common').and
+          .to.defineTemplateId('common/two.html').and
+          .to.haveContent(HTML2)
+          .to.defineModule('tpl/three.html').and
+          .to.defineTemplateId('tpl/three.html').and
+          .to.haveContent(HTML3)


### PR DESCRIPTION
`moduleName` option accepts function to dynamically generate module names

This change allows to have:

1. no modules (don't provide `moduleName` in config)
2. many templates in one module (set `moduleName` in config to desired module name)
3. many templates in several modules (set 'moduleName` to function that always returns non empty string)
4. mix 1. with 2. or  1. with 3. (set 'moduleName` to function that occasionally returns *falsy* value)

Makes #55 obsolete