### PR TITLE
Add support for Angular 2 template cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,9 @@
 
 [![Build Status](https://img.shields.io/travis/karma-runner/karma-ng-html2js-preprocessor/master.svg?style=flat-square)](https://travis-ci.org/karma-runner/karma-ng-html2js-preprocessor) [![Dependency Status](https://img.shields.io/david/karma-runner/karma-ng-html2js-preprocessor.svg?style=flat-square)](https://david-dm.org/karma-runner/karma-ng-html2js-preprocessor) [![devDependency Status](https://img.shields.io/david/dev/karma-runner/karma-ng-html2js-preprocessor.svg?style=flat-square)](https://david-dm.org/karma-runner/karma-ng-html2js-preprocessor#info=devDependencies)
 
-> Preprocessor for converting HTML files to [AngularJS 1.x](http://angularjs.org/) templates.
+> Preprocessor for converting HTML files to [AngularJS 1.x](http://angularjs.org/) and [Angular 2](http://angular.io/) templates.
 
 *Note:* If you are looking for a general preprocessor that is not tied to Angular, check out [karma-html2js-preprocessor](https://github.com/karma-runner/karma-html2js-preprocessor).
-
-*Note:* If you are using Angular 2.x, use [karma-redirect-preprocessor](https://github.com/sjelin/karma-redirect-preprocessor).
 
 ## Installation
 
@@ -132,6 +130,53 @@ angular.module('template.html', []).run(function($templateCache) {
 See the [ng-directive-testing](https://github.com/vojtajina/ng-directive-testing) for a complete example.
 
 ----
+
+## Angular2 template caching
+
+For using this preprocessor with Angular 2 templates use `angular: 2` option in the config file.
+
+```js
+// karma.conf.js
+module.exports = function(config) {
+  config.set({
+    // ...
+
+    ngHtml2JsPreprocessor: {
+      // ...
+
+      angular: 2
+    }
+  })
+}
+```
+
+The template `template.html`...
+```html
+<div>something</div>
+```
+... will be served as `template.html.js` that sets the template content in the global $templateCache variable:
+```js
+window.$templateCache = window.$templateCache || {}
+window.$templateCache['template.html'] = '<div>something</div>';
+```
+
+To use the cached templates in your Angular 2 tests use the provider for the Cached XHR implementation - `CACHED_TEMPLATE_PROVIDER` from `angular2/platform/testing/browser`. The following shows the change in `karma-test-shim.js` to use the cached XHR and template cache in all your tests.
+```js
+// karma-test-shim.js
+...
+System.import('angular2/testing').then(function(testing) {
+  return System.import('angular2/platform/testing/browser').then(function(providers) {
+    testing.setBaseTestProviders(
+      providers.TEST_BROWSER_PLATFORM_PROVIDERS,
+      [providers.TEST_BROWSER_APPLICATION_PROVIDERS, providers.CACHED_TEMPLATE_PROVIDER]);
+  });
+}).then(function() {
+...
+```
+
+Now when your component under test uses `template.html` in its `templateUrl` the contents of the template will be used from the template cache instead of making a XHR to fetch the contents of the template. This can be useful while writing fakeAsync tests where the component can be loaded synchronously without the need to make a XHR to get the templates.
+
+---
 
 For more information on Karma see the [homepage].
 

--- a/lib/html2js.js
+++ b/lib/html2js.js
@@ -17,6 +17,9 @@ var SINGLE_MODULE_TPL = '(function(module) {\n' +
 
 var REQUIRE_MODULE_TPL = 'require([\'%s\'], function(angular) {%s});\n'
 
+var ANGULAR2_TPL = 'window.$templateCache = window.$templateCache || {};\n' +
+  "window.$templateCache['%s'] = '%s';\n"
+
 var escapeContent = function (content) {
   return content.replace(/\\/g, '\\\\').replace(/'/g, "\\'").replace(/\r?\n/g, "\\n' +\n    '")
 }
@@ -36,6 +39,7 @@ var createHtml2JsPreprocessor = function (logger, basePath, config) {
   }
   var enableRequireJs = config.enableRequireJs
   var requireJsAngularId = config.requireJsAngularId || 'angular'
+  var angular = config.angular || 1
 
   return function (content, file, done) {
     log.debug('Processing "%s".', file.originalPath)
@@ -49,14 +53,18 @@ var createHtml2JsPreprocessor = function (logger, basePath, config) {
     }
 
     var tpl
-    if (moduleName) {
-      tpl = util.format(SINGLE_MODULE_TPL, moduleName, moduleName, htmlPath, escapeContent(content))
+    if (angular === 2 || angular === '2') {
+      tpl = util.format(ANGULAR2_TPL, htmlPath, escapeContent(content))
     } else {
-      tpl = util.format(TEMPLATE, htmlPath, htmlPath, escapeContent(content))
-    }
+      if (moduleName) {
+        tpl = util.format(SINGLE_MODULE_TPL, moduleName, moduleName, htmlPath, escapeContent(content))
+      } else {
+        tpl = util.format(TEMPLATE, htmlPath, htmlPath, escapeContent(content))
+      }
 
-    if (enableRequireJs) {
-      tpl = util.format(REQUIRE_MODULE_TPL, requireJsAngularId, tpl)
+      if (enableRequireJs) {
+        tpl = util.format(REQUIRE_MODULE_TPL, requireJsAngularId, tpl)
+      }
     }
 
     done(tpl)

--- a/test/html2js.spec.coffee
+++ b/test/html2js.spec.coffee
@@ -258,3 +258,17 @@ describe 'preprocessors html2js', ->
             .to.defineTemplateId('path/file.html').and
             .to.haveContent HTML
           done()
+
+    describe 'angular version 2', ->
+      it 'should store the template in window.$templateCache', (done) ->
+        process = createPreprocessor
+          angular: 2
+
+        file = new File '/base/path/file.html'
+        HTML  = '<html>test</html>'
+
+        process HTML, file, (processedContent) ->
+          expect(processedContent)
+            .to.defineAngular2TemplateId('path/file.html').and
+            .to.haveContent HTML
+          done()


### PR DESCRIPTION
Add a config option "angular" which when set to 2 will output a JS file that will populate window.$templateCache with the contents of the template HTML.

This can be then used by Angular 2 tests to avoid having to make an XHR for fetching template HTML-s.