### PR TITLE
Fixed example configuration to not use non-existing String.strip.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ module.exports = function(config) {
       cacheIdFromPath: function(filepath) {
         // example strips 'public/' from anywhere in the path
         // module(app/templates/template.html) => app/public/templates/template.html
-        var cacheId = filepath.strip('public/', '');
+        var cacheId = filepath.replace('public/', '');
         return cacheId;
       },
 


### PR DESCRIPTION
filepath.strip is not a function, so I would replace it with replace. See #90
