### PR TITLE
Fix typo str.strip() -> str.replace()

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ module.exports = function(config) {
       cacheIdFromPath: function(filepath) {
         // example strips 'public/' from anywhere in the path
         // module(app/templates/template.html) => app/public/templates/template.html
-        var cacheId = filepath.strip('public/', '');
+        var cacheId = filepath.replace('public/', '');
         return cacheId;
       },
 


### PR DESCRIPTION
String `strip()` method doesn't exist in JavaScript. Use `replace()` instead. 

See: https://www.w3schools.com/jsref/jsref_replace.asp